### PR TITLE
Fix logic issue,

### DIFF
--- a/src/app/modules/search/components/search/search.component.ts
+++ b/src/app/modules/search/components/search/search.component.ts
@@ -89,7 +89,9 @@ export class SearchComponent implements OnInit {
                     }
                 }
                 if (foundKey) {
-                    searchQuery.rules[i].query.operator = 'OR';
+                    if (key !== 'omics_type') {
+                        searchQuery.rules[i].query.operator = 'OR';
+                    }
                     const rule = new Rule();
                     rule.field = key;
                     rule.data = facet;


### PR DESCRIPTION
In the old system, if the facet is 'omics_type' then the operation always to be 'AND'