### PR TITLE
Fixed 'TypeError: Cannot read property 'replace' of null' error 

### DIFF
--- a/src/app/shared/utils/object-utils.ts
+++ b/src/app/shared/utils/object-utils.ts
@@ -8,7 +8,7 @@ export class ObjectUtils {
     }
 
     static upperName(lower: string) {
-        return lower.replace(/^\w/, function (chr) {
+        return lower == null ? "" : lower.replace(/^\w/, function (chr) {
             return chr.toUpperCase();
         });
     }


### PR DESCRIPTION
...that is bloating prod error logs to hundreds of GBs in size